### PR TITLE
Fix sticker-creator bug

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -4,7 +4,7 @@
 pkgname=signal-desktop
 _pkgname=Signal-Desktop
 pkgver=6.44.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Signal Private Messenger for Linux"
 license=('AGPL-3.0-only')
 arch=('x86_64')
@@ -60,6 +60,11 @@ prepare() {
 build() {
   cd "${_pkgname}-${pkgver}"
   yarn generate
+  yarn build
+
+  cd sticker-creator
+  rm -rf dist
+  yarn install
   yarn build
 }
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -72,6 +72,8 @@ package() {
   cd "${_pkgname}-${pkgver}"
 
   install -d "${pkgdir}/usr/"{lib,bin}
+  mkdir release/linux-unpacked/sticker-creator
+  cp -a sticker-creator/dist release/linux-unpacked/sticker-creator/dist
   cp -a release/linux-unpacked "${pkgdir}/usr/lib/${pkgname}"
   ln -s "/usr/lib/${pkgname}/${pkgname}" "${pkgdir}/usr/bin/"
 


### PR DESCRIPTION
Built files also need to be copied over. I opted for copying to `release/linux-unpacked`, but probably can be copied directly to `/usr/lib`. 
1st commit is your change rebased, 2nd commit is my change.
Tested and it works!
(I've enabled edits by maintainers, so feel free to squash it or something, if you want)